### PR TITLE
Feature/misc cosmetic updates

### DIFF
--- a/app/assets/stylesheets/greghome/styles.scss
+++ b/app/assets/stylesheets/greghome/styles.scss
@@ -67,6 +67,7 @@ a {
   }
   &:focus {
     outline: none;
+    background-color: rgba(0,0,0,0.2);
   }
 
 }
@@ -137,7 +138,7 @@ div.QuickLinksPanel {
   display: inline-block;
   background: rgba(0,0,0,0.3);
   border-radius: 12px;
-  li:hover a:after{
+  li a:hover:after{
     width: 100%;
   }
 }

--- a/todo_list.md
+++ b/todo_list.md
@@ -1,4 +1,4 @@
-# Greg's To Do List
+# To Do List
 
 * Prevent direct pushes to Master
 * Tests! Write the tests that you should've written at the outset!


### PR DESCRIPTION
On Greghome, only underline links when the link is in `:hover` state, not when its containing `<li>` is in `:hover`.

Also, prevent pushing directly to `master`, so I have to use a PR to update master from now on.