### PR TITLE
fix markdown in ratrace posts, and remove post to facebook option

### DIFF
--- a/app/views/ratrace/posts/edit.html.erb
+++ b/app/views/ratrace/posts/edit.html.erb
@@ -11,8 +11,8 @@
 <div class='panel-body edit-post'>
   <%= form_for @post do |f| %>
     <%= f.text_field :title, class: 'input' %>
-    <%= md_editor do %>
-      <%= f.input :body, label: false, class: 'input' %>
+    <%= md_simple_editor do %>
+      <%= f.text_area :body, label: false, class: 'input' %>
     <% end %>
 
     <div class='actions'>

--- a/app/views/ratrace/posts/index.html.erb
+++ b/app/views/ratrace/posts/index.html.erb
@@ -16,9 +16,11 @@
     <% end %>
     <div class='actions'>
       <label class='lefty'>Upload a JPG Image<span><%= f.file_field :image %></span></label>
-      <%= f.label :post_to_facebook, class: 'lefty' do %>
-        <%= f.check_box :post_to_facebook, value: 'Y', class: 'input' %>
-        Post update to Facebook
+      <% if false %>
+        <%= f.label :post_to_facebook, class: 'lefty' do %>
+          <%= f.check_box :post_to_facebook, value: 'Y', class: 'input' %>
+          Post update to Facebook
+        <% end %>
       <% end %>
       <%= f.submit "Save" %>
     </div>


### PR DESCRIPTION
Facebook now only allows `publish_actions` for 'approved partners', which I'm not, so now my app can't post my posts to my Facebook timeline. Ah well.